### PR TITLE
fix apt Unable to locate package lib32stdc++-4.9-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:slim
 
 MAINTAINER random_robbie <txt3rob@gmail.com>
+WORKDIR /root
 
 #Set Env
 ENV LC_ALL C.UTF-8
@@ -14,7 +15,7 @@ RUN apt-get update
 RUN apt-get upgrade -y
 
 #Install Frida
-RUN apt-get install -y unzip bash git nano gcc-multilib lib32stdc++-4.9-dev zlib1g-dev lib32z1-dev python3 python3-dev python3-pip git autotools-dev automake
+RUN apt-get install -y unzip bash git nano gcc-multilib libstdc++6 zlib1g-dev lib32z1-dev python3 python3-dev python3-pip git autotools-dev automake apt-utils curl
 RUN pip3 install colorama prompt-toolkit pygments
 RUN pip3 install frida
 RUN npm install frida
@@ -28,5 +29,4 @@ RUN unzip /tmp/adb.zip -d $ANDROID_HOME
 ADD frida-android-repinning_sa-1.js /root/frida-android-repinning_sa-1.js
 ADD burpca-cert-der.crt /root/burpca-cert-der.crt
 
-WORKDIR /root/
 ENTRYPOINT ["bash"]


### PR DESCRIPTION
used `libstdc++6`. Plus `curl` package